### PR TITLE
chore: remove Token Balances by wallet

### DIFF
--- a/api/alchemyApi.ts
+++ b/api/alchemyApi.ts
@@ -104,21 +104,5 @@ export const alchemyApi = {
       console.error('Error fetching token data:', error);
       throw error;
     }
-  },
-  async getTokenBalancesByMultichainWallet(params: MultiChainTokenByAddress) {
-    try {
-      const response = await multiChainTokenClient.post('/by-address', {
-        addresses: params.addresses.map((pair: MultiChainTokenByAddressPair) => ({
-          address: pair.address,
-          networks: pair.networks 
-        }))
-      });
-
-      const responseData = convertHexBalanceToDecimal(response);
-      return responseData;
-    } catch (error) {
-      console.error('Error fetching token balances:', error);
-      throw error;
-    }
   }
 };

--- a/index.ts
+++ b/index.ts
@@ -121,33 +121,6 @@ server.tool('getTokensByMultichainAddress', {
   }
 });
 
-// Fetches current balances for multiple addresses using network and address pairs.
-server.tool('getTokenBalancesByMultichainWallet', {
-  addresses: z.array(z.object({
-    address: z.string().describe('The wallet address to query. e.g. "0x1234567890123456789012345678901234567890"'),
-    networks: z.array(z.string()).describe('The blockchain networks to query. e.g. ["eth-mainnet", "base-mainnet"]')
-  })).describe('A list of wallet address and network pairs'),
-}, async (params) => {
-  try {
-    const result = await alchemyApi.getTokenBalancesByMultichainWallet(params);
-    return {
-      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-    };
-  } catch (error) {
-    if (error instanceof Error) {
-      console.error('Error in getTokenBalancesByMultichainWallet:', error);
-      return {
-        content: [{ type: "text", text: `Error: ${error.message}` }],
-        isError: true
-      };
-    }
-    return {
-      content: [{ type: "text", text: 'Unknown error occurred' }],
-      isError: true
-    };
-  }
-});
-
 // || ** NFT API ** ||
 
 // Get NFTs owned by an address

--- a/utils/convertHexBalanceToDecimal.ts
+++ b/utils/convertHexBalanceToDecimal.ts
@@ -10,7 +10,7 @@ export default function convertHexBalanceToDecimal(response: any) {
         try {
           const processedToken = { ...token };
           const hexTokenBalance = token.tokenBalance;
-          const tokenDecimals = parseInt(token.tokenMetadata.decimals || '0', 10);
+          const tokenDecimals = parseInt(token.tokenMetadata.decimals || '18', 10);
           
           const bigIntBalance = BigInt(hexTokenBalance);
           const decimalBalance = Number(bigIntBalance) / Math.pow(10, tokenDecimals);


### PR DESCRIPTION
This method does not return enough data for us to use properly without either:

1. Making another API call to grab the token Symbol from the `tokenAddress`
2. Storing the contract addresses for all non-standard decimal tokens across all chains