### PR TITLE
Add MCP Registry metadata for hosted remote server

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.alchemyplatform/alchemy-mcp-server",
+  "title": "Alchemy",
+  "description": "Alchemy's hosted MCP server for blockchain APIs and onchain data.",
+  "repository": {
+    "url": "https://github.com/alchemyplatform/alchemy-mcp-server",
+    "source": "github"
+  },
+  "version": "0.3.0-remote.1",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.alchemy.com/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a  file for MCP Registry publishing
- register the hosted Alchemy MCP endpoint at 
- publish the entry as a remote Streamable HTTP server instead of the local npm package

## Notes
- this points the registry at the hosted OAuth-backed server described in the README
- it intentionally does not add local stdio package metadata