### PR TITLE
Handle metadata flags before server startup

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,26 @@ import { setupDi } from "./di/di-container.js";
 import { ClientsModule } from "./di/modules/clients.module.js";
 import pkg from "./package.json" with { type: "json" };
 
+const flag = process.argv[2];
+
+if (flag === "--version" || flag === "-v") {
+  process.stdout.write(`${pkg.version}\n`);
+  process.exit(0);
+}
+
+if (flag === "--help" || flag === "-h") {
+  process.stdout.write(`Alchemy MCP Server ${pkg.version}
+
+Usage:
+  mcp-server-alchemy [options]
+
+Options:
+  -h, --help      Show this help message
+  -v, --version   Show version number
+`);
+  process.exit(0);
+}
+
 dotenv.config();
 
 // ========================================

--- a/tests/cli-metadata.test.ts
+++ b/tests/cli-metadata.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert";
+import { spawnSync } from "node:child_process";
+import { describe, it } from "node:test";
+
+import pkg from "../package.json" with { type: "json" };
+
+function runCli(flag: string) {
+  return spawnSync("pnpm", ["exec", "tsx", "index.ts", flag], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    timeout: 3000,
+  });
+}
+
+describe("CLI metadata flags", () => {
+  it("prints the package version without starting the server", () => {
+    const result = runCli("--version");
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), pkg.version);
+    assert.equal(result.stderr, "");
+  });
+
+  it("prints help without starting the server", () => {
+    const result = runCli("--help");
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Usage:/);
+    assert.match(result.stdout, /--version/);
+    assert.equal(result.stderr, "");
+  });
+});


### PR DESCRIPTION
## Summary
- handle `--help`, `-h`, `--version`, and `-v` before starting the stdio MCP server
- keep the existing no-arg stdio startup path unchanged
- add regression coverage for CLI metadata flags

## Why
The published `mcp-server-alchemy` bin currently treats metadata flags as normal server startup, so `--version` and `--help` print the stdio startup message instead of returning CLI metadata.

## Validation
- `pnpm exec tsx --test tests/cli-metadata.test.ts`
- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm exec eslint index.ts tests/cli-metadata.test.ts`
- `pnpm pack --pack-destination /tmp/automoney-alchemy-pack`
- `npm exec --yes --package=/tmp/automoney-alchemy-pack/alchemy-mcp-server-0.3.0.tgz -- mcp-server-alchemy --version`
- `npm exec --yes --package=/tmp/automoney-alchemy-pack/alchemy-mcp-server-0.3.0.tgz -- mcp-server-alchemy --help`
- no-arg tarball smoke still starts the stdio path